### PR TITLE
Version Build Files (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "babel-preset-react": "^6.23.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.27.3",
+    "html-webpack-plugin": "^2.30.1",
     "node-sass": "^4.5.2",
     "postcss-loader": "^1.3.3",
     "sass-loader": "^6.0.3",
     "style-loader": "^0.16.1",
     "webpack": "^2.3.2",
-    "webpack-dev-server": "^2.4.2"
+    "webpack-dev-server": "^2.4.2",
+    "webpack-git-hash": "^1.0.2"
   },
   "dependencies": {
     "normalize.css": "^6.0.0",

--- a/source/html/index.html
+++ b/source/html/index.html
@@ -10,10 +10,5 @@
 
 <body>
 <div id="app" />
-
-<script src="vendor.bundle.js" type="text/javascript"></script>
-<script src="bundle.js" type="text/javascript"></script>
-
 </body>
-
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,28 +4,30 @@ const webpack = require('webpack');
 const path = require('path');
 const autoprefixer = require('autoprefixer');
 const copy = require('copy-webpack-plugin');
+const versioner = require('webpack-git-hash');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 // var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const BUILD_DIR = path.resolve(__dirname, 'public');
 const APP_DIR = path.resolve(__dirname, 'source');
 
 const config = {
-	
+
     entry: {
         app: [APP_DIR + '/index.jsx'],
         vendor: ['react', 'react-dom', 'react-router']
     },
-	
+
     output: {
         path: BUILD_DIR,
-        filename: 'bundle.js'
+        filename: 'bundle.[githash].js'
     },
-	
+
     context: path.join(__dirname, 'source'),
-    
+
 	module: {
         loaders : [
-		
+
             {
                 test: /\.jsx?/,
                 exclude : [/node_modules/, /bower_components/],
@@ -35,21 +37,21 @@ const config = {
                     presets: ['es2015']
                 }
             },
-			
+
             {
                 test: /\.scss$/,
                 // loader: ExtractTextPlugin.extract('css!sass')
                 loaders: ['style-loader', 'css-loader?url=false', 'sass-loader', 'postcss-loader']
             },
-			
+
             {
                 test: /\.css$/,
                 loaders: ['style-loader', 'css-loader?url=false', 'postcss-loader']
             }
-			
+
         ]
     },
-	
+
     plugins: [
         new copy([
             {from: APP_DIR + '/html/', to: BUILD_DIR},
@@ -63,7 +65,12 @@ const config = {
             name: 'vendor',
             minChunks: Infinity,
             filename: 'vendor.bundle.js'
-        })
+        }),
+
+				new versioner(),
+        new HtmlWebpackPlugin({
+					template: APP_DIR + '/html/index.html',
+				})
     ]
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,7 +70,7 @@ const config = {
         new versioner(),
 
         new HtmlWebpackPlugin({
-          template: APP_DIR + 'html/index.html'
+          template: APP_DIR + '/html/index.html'
         })
     ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,10 +67,11 @@ const config = {
             filename: 'vendor.bundle.js'
         }),
 
-				new versioner(),
+        new versioner(),
+
         new HtmlWebpackPlugin({
-					template: APP_DIR + '/html/index.html',
-				})
+          template: APP_DIR + 'html/index.html'
+        })
     ]
 };
 


### PR DESCRIPTION
- [x] Versions the build `bundle.js` file so that it is automatically updated in CloudFront cache' when new versions are deployed

I think the proper way to do this would be to version all static assets, but I haven't been able to the `copy-webpack-plugin` to play nice with it and automatically manifest the versioned file names. Probably @bluedrops should take a look at that...