### PR TITLE
Replace versioning with global invalidations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+      - python3-pip
 cache:
   directories:
     - node_modules
@@ -17,6 +18,8 @@ before_script:
   - npm install
 script:
   - npm run build
+before_deploy:
+  - pip install --upgrade --user awscli
 deploy:
   provider: s3
   access_key_id: $HACKILLINOIS_ACCESS_KEY_ID
@@ -24,3 +27,10 @@ deploy:
   bucket: $HACKILLINOIS_BUCKET_NAME
   skip_cleanup: true
   local_dir: public
+after_deploy:
+  - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION --paths '/*'
+  - curl -X DELETE "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_IDENTIFIER/purge_cache" \
+     -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
+     -H "X-Auth-Key: $CLOUDFLARE_API_KEY" \
+     -H "Content-Type: application/json" \
+     --data '{"purge_everything":true}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_deploy:
   - pip install --upgrade --user awscli
 deploy:
   provider: s3
-  access_key_id: $HACKILLINOIS_ACCESS_KEY_ID
-  secret_access_key: $HACKILLINOIS_SECRET_ACCESS_KEY
+  access_key_id: $AWS_ACCESS_KEY_ID
+  secret_access_key: $AWS_SECRET_ACCESS_KEY
   bucket: $HACKILLINOIS_BUCKET_NAME
   skip_cleanup: true
   local_dir: public

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,4 @@ deploy:
   skip_cleanup: true
   local_dir: public
 after_deploy:
-  - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION --paths '/*'
-  - curl -X DELETE "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_IDENTIFIER/purge_cache" \
-     -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
-     -H "X-Auth-Key: $CLOUDFLARE_API_KEY" \
-     -H "Content-Type: application/json" \
-     --data '{"purge_everything":true}'
+  - ./scripts/invalidate.sh

--- a/package.json
+++ b/package.json
@@ -18,14 +18,12 @@
     "babel-preset-react": "^6.23.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.27.3",
-    "html-webpack-plugin": "^2.30.1",
     "node-sass": "^4.5.2",
     "postcss-loader": "^1.3.3",
     "sass-loader": "^6.0.3",
     "style-loader": "^0.16.1",
     "webpack": "^2.3.2",
-    "webpack-dev-server": "^2.4.2",
-    "webpack-git-hash": "^1.0.2"
+    "webpack-dev-server": "^2.4.2"
   },
   "dependencies": {
     "normalize.css": "^6.0.0",

--- a/scripts/invalidate.sh
+++ b/scripts/invalidate.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-AWS_ACCESS_KEY_ID=$HACKILLINOIS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY=$HACKILLINOIS_SECRET_ACCESS_KEY
-
 aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION --paths '/*'
 curl -X DELETE "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_IDENTIFIER/purge_cache" \
   -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \

--- a/scripts/invalidate.sh
+++ b/scripts/invalidate.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+AWS_ACCESS_KEY_ID=$HACKILLINOIS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY=$HACKILLINOIS_SECRET_ACCESS_KEY
+
+aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION --paths '/*'
+curl -X DELETE "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_IDENTIFIER/purge_cache" \
+  -H "X-Auth-Email: $CLOUDFLARE_AUTH_EMAIL" \
+  -H "X-Auth-Key: $CLOUDFLARE_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{"purge_everything":true}'

--- a/source/html/index.html
+++ b/source/html/index.html
@@ -10,5 +10,9 @@
 
 <body>
 <div id="app" />
+
+<script type="text/javascript" src="vendor.bundle.js"></script>
+<script type="text/javascript" src="bundle.js"></script>
+
 </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,8 +4,6 @@ const webpack = require('webpack');
 const path = require('path');
 const autoprefixer = require('autoprefixer');
 const copy = require('copy-webpack-plugin');
-const versioner = require('webpack-git-hash');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 // var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 const BUILD_DIR = path.resolve(__dirname, 'public');
@@ -20,7 +18,7 @@ const config = {
 
     output: {
         path: BUILD_DIR,
-        filename: 'bundle.[githash].js'
+        filename: 'bundle.js'
     },
 
     context: path.join(__dirname, 'source'),
@@ -54,8 +52,14 @@ const config = {
 
     plugins: [
         new copy([
-            {from: APP_DIR + '/html/', to: BUILD_DIR},
-            {from: APP_DIR + '/assets/', to: BUILD_DIR + '/assets/'}
+            {
+              from: APP_DIR + '/html/',
+              to: BUILD_DIR
+            },
+            {
+              from: APP_DIR + '/assets/',
+              to: BUILD_DIR + '/assets/'
+            }
         ], {
             copyUnmodified: false,
             debug: 'debug'
@@ -66,12 +70,6 @@ const config = {
             minChunks: Infinity,
             filename: 'vendor.bundle.js'
         }),
-
-        new versioner(),
-
-        new HtmlWebpackPlugin({
-          template: APP_DIR + '/html/index.html'
-        })
     ]
 };
 


### PR DESCRIPTION
Prior to this pull, only the `bundle.js` was being properly versioned, and versioning everything else was proving to be difficult, and `index.js` would need Cloudflare and Cloudfront invalidations anyways, and since the footprint of our page will be low, invalidating everything on both distribution services is inexpensive.

- [x] Removed versioning
- [x] Added cache invalidation to CD build